### PR TITLE
Add AssetLicence to AssetAdmListDto

### DIFF
--- a/src/Model/Dto/Asset/AssetAdmListDto.php
+++ b/src/Model/Dto/Asset/AssetAdmListDto.php
@@ -6,6 +6,7 @@ namespace AnzuSystems\CoreDamBundle\Model\Dto\Asset;
 
 use AnzuSystems\CoreDamBundle\Entity\Asset;
 use AnzuSystems\CoreDamBundle\Entity\AssetFile;
+use AnzuSystems\CoreDamBundle\Entity\AssetLicence;
 use AnzuSystems\CoreDamBundle\Entity\PodcastEpisode;
 use AnzuSystems\CoreDamBundle\Model\Dto\AbstractEntityDto;
 use AnzuSystems\CoreDamBundle\Model\Dto\Asset\Embeds\AssetAttributesAdmDto;
@@ -15,6 +16,7 @@ use AnzuSystems\CoreDamBundle\Model\Enum\AssetType;
 use AnzuSystems\CoreDamBundle\Serializer\Handler\Handlers\AssetFileHandler;
 use AnzuSystems\CoreDamBundle\Serializer\Handler\Handlers\ImageLinksHandler;
 use AnzuSystems\SerializerBundle\Attributes\Serialize;
+use AnzuSystems\SerializerBundle\Handler\Handlers\EntityIdHandler;
 
 class AssetAdmListDto extends AbstractEntityDto
 {
@@ -103,5 +105,11 @@ class AssetAdmListDto extends AbstractEntityDto
         }
 
         return [];
+    }
+
+    #[Serialize(handler: EntityIdHandler::class)]
+    public function getLicence(): AssetLicence
+    {
+        return $this->getAsset()->getLicence();
     }
 }


### PR DESCRIPTION
The "AssetLicence" class is now imported from the CoreDamBundle. Also, a getLicence method decorated with the Serialize annotation and EntityIdHandler has been added to the AssetAdmListDto class to return the licence attached to an asset.