### PR TITLE
fix #85265 follow redirects for untrusted url file downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+* Fix url asset file download refusing redirects for untrusted hosts (`1.48.0` regression) — podcast enclosures are redirect trackers, so the empty `302` body was stored as the audio file and the asset failed on `invalid_mime_type` (`application/x-empty`)
+* Fail url asset file download on any non-`2xx` status instead of writing an empty file
+
 ## [1.40.0](https://github.com/anzusystems/core-dam-bundle/compare/1.39.0...1.40.0) (2025-09-22)
 
 ### Features

--- a/src/Doctrine/Type/ColorType.php
+++ b/src/Doctrine/Type/ColorType.php
@@ -22,9 +22,9 @@ final class ColorType extends AbstractValueObjectType
 
         try {
             /**
-             * @var string $r
-             * @var string $g
-             * @var string $b
+             * @var non-empty-string $r
+             * @var non-empty-string $g
+             * @var non-empty-string $b
              *
              * @psalm-suppress PossiblyUndefinedArrayOffset
              */

--- a/src/Domain/AssetFile/FileFactory/UrlFileFactory.php
+++ b/src/Domain/AssetFile/FileFactory/UrlFileFactory.php
@@ -23,11 +23,12 @@ use Throwable;
 
 final readonly class UrlFileFactory
 {
-    public const int TRUSTED_MAX_REDIRECTS = 5;
+    public const int MAX_REDIRECTS = 5;
     public const int MAX_DOWNLOAD_BYTES = 2_147_483_648;
     private const int TIMEOUT = 600;
     private const int MAX_DURATION = 600;
     private const string HTTPS_SCHEME = 'https';
+    private const string HTTPS_PREFIX = self::HTTPS_SCHEME . '://';
 
     private HttpClientInterface $trustedClient;
     private HttpClientInterface $safeClient;
@@ -45,8 +46,8 @@ final readonly class UrlFileFactory
         string $urlFileTrustedDomains = '',
         bool $urlFileAllowPrivateNetworks = false,
     ) {
-        // Trust only relaxes https-only and allows capped redirects; the private-network guard stays on
-        // every redirect hop. The dev-only flag lifts it so local domains (sme.local → 127.0.0.1) work.
+        // Trust only relaxes the https-only rule; the private-network guard stays on every redirect hop.
+        // The dev-only flag lifts it so local domains (sme.local → 127.0.0.1) work.
         $this->trustedClient = $urlFileAllowPrivateNetworks ? $client : new NoPrivateNetworkHttpClient($client);
         $this->safeClient = new NoPrivateNetworkHttpClient($client);
         $this->urlFileTrustedDomains = array_values(array_filter(array_map(
@@ -78,10 +79,18 @@ final readonly class UrlFileFactory
         $options = [
             'timeout' => self::TIMEOUT,
             'max_duration' => self::MAX_DURATION,
-            'max_redirects' => $trusted ? self::TRUSTED_MAX_REDIRECTS : 0,
-            'on_progress' => static function (int $dlNow, int $dlSize): void {
+            // Podcast enclosures are redirect trackers (traffic.omny.fm → CDN), so untrusted hosts need a
+            // budget too; NoPrivateNetworkHttpClient re-resolves and re-checks the target IP on every hop.
+            'max_redirects' => self::MAX_REDIRECTS,
+            'on_progress' => static function (int $dlNow, int $dlSize, array $info) use ($trusted): void {
                 if ($dlNow > self::MAX_DOWNLOAD_BYTES || $dlSize > self::MAX_DOWNLOAD_BYTES) {
                     throw new RuntimeException(sprintf('download_size_exceeded (max %d bytes)', self::MAX_DOWNLOAD_BYTES));
+                }
+
+                // Keeps https-only true across hops — a redirect must not downgrade an untrusted download.
+                $hopUrl = $info['url'] ?? null;
+                if (false === $trusted && is_string($hopUrl) && false === str_starts_with(strtolower($hopUrl), self::HTTPS_PREFIX)) {
+                    throw new RuntimeException('untrusted_non_https_redirect');
                 }
             },
         ];
@@ -94,8 +103,11 @@ final readonly class UrlFileFactory
                 options: $options,
             );
 
-            if (Response::HTTP_BAD_REQUEST <= $response->getStatusCode()) {
-                throw new AssetFileProcessFailed(AssetFileFailedType::DownloadFailed);
+            $statusCode = $response->getStatusCode();
+            // Anything but 2xx has no payload — an unfollowed 3xx used to yield a 0-byte file that only
+            // surfaced later as an invalid_mime_type (application/x-empty) on the asset file.
+            if (Response::HTTP_OK > $statusCode || Response::HTTP_MULTIPLE_CHOICES <= $statusCode) {
+                throw new RuntimeException(sprintf('unexpected_status (%d)', $statusCode));
             }
 
             $fileSystem = $this->fileSystemProvider->getTmpFileSystem();

--- a/tests/Domain/AssetFile/FileFactory/UrlFileFactoryTest.php
+++ b/tests/Domain/AssetFile/FileFactory/UrlFileFactoryTest.php
@@ -50,7 +50,7 @@ final class UrlFileFactoryTest extends CoreDamKernelTestCase
         $this->factory(allowPrivateNetworks: true)->downloadFile('http://127.0.0.1/a.mp3');
 
         self::assertCount(1, $this->requests);
-        self::assertSame(UrlFileFactory::TRUSTED_MAX_REDIRECTS, $this->requests[0]['options']['max_redirects']);
+        self::assertSame(UrlFileFactory::MAX_REDIRECTS, $this->requests[0]['options']['max_redirects']);
     }
 
     // Matcher logic only — hostnames don't resolve, so the raw dev-mode client keeps this deterministic.
@@ -62,12 +62,34 @@ final class UrlFileFactoryTest extends CoreDamKernelTestCase
         self::assertCount(2, $this->requests);
     }
 
-    public function testUntrustedHttpsGetsZeroRedirects(): void
+    // Podcast enclosures (traffic.omny.fm → CDN) are untrusted redirect trackers; refusing to follow them
+    // wrote the empty 302 body as the audio file and the asset failed later on invalid_mime_type.
+    public function testUntrustedRedirectIsFollowedToThePayload(): void
     {
-        $this->factory()->downloadFile('https://8.8.8.8/a.mp3');
+        $file = $this->factory([
+            new MockResponse('', ['http_code' => 302, 'redirect_url' => 'https://8.8.4.4/final.mp3']),
+            new MockResponse('mp3-bytes', ['http_code' => 200]),
+        ])->downloadFile('https://8.8.8.8/a.mp3');
 
-        self::assertCount(1, $this->requests);
-        self::assertSame(0, $this->requests[0]['options']['max_redirects']);
+        self::assertCount(2, $this->requests);
+        self::assertSame('mp3-bytes', file_get_contents((string) $file->getRealPath()));
+    }
+
+    public function testUnfollowedRedirectFailsInsteadOfWritingEmptyFile(): void
+    {
+        $this->expectException(AssetFileProcessFailed::class);
+
+        $this->factory([new MockResponse('', ['http_code' => 302])])->downloadFile('https://8.8.8.8/a.mp3');
+    }
+
+    public function testUntrustedHttpsDowngradeOnRedirectIsRejected(): void
+    {
+        $this->expectException(AssetFileProcessFailed::class);
+
+        $this->factory([
+            new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://8.8.4.4/final.mp3']),
+            new MockResponse('mp3-bytes', ['http_code' => 200]),
+        ])->downloadFile('https://8.8.8.8/a.mp3');
     }
 
     #[DataProvider('provideRejectedUrls')]
@@ -118,15 +140,19 @@ final class UrlFileFactoryTest extends CoreDamKernelTestCase
     {
         $this->expectException(AssetFileProcessFailed::class);
 
-        $this->factory(new MockResponse('', ['http_code' => 404]))->downloadFile('https://8.8.8.8/a.mp3');
+        $this->factory([new MockResponse('', ['http_code' => 404])])->downloadFile('https://8.8.8.8/a.mp3');
     }
 
-    private function factory(?MockResponse $response = null, bool $allowPrivateNetworks = false): UrlFileFactory
+    /**
+     * @param list<MockResponse> $responses
+     */
+    private function factory(array $responses = [], bool $allowPrivateNetworks = false): UrlFileFactory
     {
-        $client = new MockHttpClient(function (string $method, string $url, array $options) use ($response): MockResponse {
+        $queue = $responses;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$queue): MockResponse {
             $this->requests[] = ['url' => $url, 'options' => $options];
 
-            return $response ?? new MockResponse('mp3-bytes', ['http_code' => 200]);
+            return array_shift($queue) ?? new MockResponse('mp3-bytes', ['http_code' => 200]);
         });
 
         return new UrlFileFactory(


### PR DESCRIPTION
The SSRF hardening set max_redirects to 0 for untrusted hosts, but the status check only rejected >= 400. A 302 therefore passed as success and its empty body was stored as the asset file, surfacing later as invalid_mime_type (application/x-empty). Podcast enclosures are redirect trackers (traffic.omny.fm -> CDN), so every rss import broke.

NoPrivateNetworkHttpClient follows redirects itself and re-resolves plus re-checks the target IP on every hop, so the private-network guard is unaffected by restoring the redirect budget. The https-only rule for untrusted hosts is now enforced per hop instead of via max_redirects, and any non-2xx status fails explicitly instead of writing an empty file.