### PR TITLE
ref #86101 scale free tts preview to a share of the narration

### DIFF
--- a/src/Domain/Tts/Config.php
+++ b/src/Domain/Tts/Config.php
@@ -28,6 +28,9 @@ final readonly class Config
         private int $audioRetentionGraceSeconds,
         private bool $loudnessNormalizationEnabled,
         private float $targetLufs,
+        private int $previewMinDurationSeconds = 30,
+        private int $previewMaxDurationSeconds = 90,
+        private float $previewDurationRatio = 0.4,
     ) {
         if ($loudnessNormalizationEnabled && ($targetLufs < self::TARGET_LUFS_MIN || $targetLufs > self::TARGET_LUFS_MAX)) {
             throw new RuntimeException(sprintf(
@@ -37,6 +40,20 @@ final readonly class Config
                 $targetLufs,
             ));
         }
+    }
+
+    /**
+     * A short narration unlocks at most the configured ratio of its length; a long one caps at the max preview length.
+     */
+    public function getPreviewDurationSeconds(int $masterDurationSeconds): int
+    {
+        return min(
+            $this->previewMaxDurationSeconds,
+            max(
+                $this->previewMinDurationSeconds,
+                (int) floor($masterDurationSeconds * $this->previewDurationRatio),
+            ),
+        );
     }
 
     public function getTargetLufs(): ?float

--- a/src/Domain/Tts/Pipeline/PreviewMedia.php
+++ b/src/Domain/Tts/Pipeline/PreviewMedia.php
@@ -30,7 +30,6 @@ use Symfony\Component\HttpFoundation\File\File;
 /** Generates the short-clip preview AudioFile for the master's asset. */
 final readonly class PreviewMedia
 {
-    private const int PREVIEW_DURATION_SECONDS = 30;
     private const int PREVIEW_START_SECONDS = 0;
     private const int PREVIEW_PATH_RANDOM_BYTES = 8;
     private const int PREVIEW_ROUTE_RANDOM_BYTES = 16;
@@ -44,6 +43,7 @@ final readonly class PreviewMedia
         private AudioStatusFacade $audioStatusFacade,
         private FfmpegService $ffmpegService,
         private EntityManagerInterface $entityManager,
+        private Config $config,
     ) {
     }
 
@@ -65,7 +65,7 @@ final readonly class PreviewMedia
             $previewFile = $this->ffmpegService->clipAudio(
                 $masterLocalFile,
                 self::PREVIEW_START_SECONDS,
-                self::PREVIEW_DURATION_SECONDS,
+                $this->config->getPreviewDurationSeconds($masterAudioFile->getAttributes()->getDuration()),
             );
 
             /** @var array{0: AudioFile, 1: AssetFileRoute} $created */

--- a/tests/Domain/Tts/ConfigTest.php
+++ b/tests/Domain/Tts/ConfigTest.php
@@ -52,6 +52,28 @@ final class ConfigTest extends TestCase
         yield 'just past the quiet boundary' => [Config::TARGET_LUFS_MIN - 0.01];
     }
 
+    #[DataProvider('providePreviewDurations')]
+    public function testPreviewDurationClampsRatioBetweenMinAndMax(int $masterDurationSeconds, int $expected): void
+    {
+        self::assertSame(
+            $expected,
+            self::config(enabled: false, targetLufs: 0.0)->getPreviewDurationSeconds($masterDurationSeconds),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function providePreviewDurations(): iterable
+    {
+        yield 'unprocessed master (0s) falls back to the minimum' => [0, 30];
+        yield 'short narration stays at the minimum' => [60, 30];
+        yield 'mid-length narration unlocks the ratio share' => [150, 60];
+        yield 'fraction floors so at most the ratio share unlocks' => [149, 59];
+        yield 'boundary narration reaches the maximum exactly' => [225, 90];
+        yield 'long narration caps at the maximum' => [600, 90];
+    }
+
     private static function config(bool $enabled, float $targetLufs): Config
     {
         return new Config(


### PR DESCRIPTION
The preview clip was a fixed 30s. It now unlocks a configurable share of the master duration, clamped between a min and a max, so short articles stay proportionally limited while long ones cap out. Defaults keep the previous minimum and are overridden by the host app.